### PR TITLE
fix(billing): Robust Stripe tier resolution with lookup_key fallback

### DIFF
--- a/apps/api/src/routes/billing.ts
+++ b/apps/api/src/routes/billing.ts
@@ -43,8 +43,8 @@ const getTierFromPrice = (price?: Stripe.Price | null): SubscriptionTier => {
   if (priceId === priceTeam) return 'TEAM';
 
   // Check by Lookup Key (Fallback/Robustness)
-  if (lookupKey === 'pro_monthly' || lookupKey === 'pro_yearly') return 'PRO';
-  if (lookupKey === 'team_monthly' || lookupKey === 'team_yearly') return 'TEAM';
+  if (lookupKey?.startsWith('pro_')) return 'PRO';
+  if (lookupKey?.startsWith('team_')) return 'TEAM';
 
   console.warn(`[Billing] Price mismatch. ID: ${priceId}, Lookup: ${lookupKey}. Defaulting to FREE.`);
   return 'FREE';
@@ -261,7 +261,7 @@ billing.post('/webhook', async (c) => {
           expand: ['items.data.price'],
         });
         const price = subscription.items.data[0]?.price;
-        const tier = getTierFromPrice(price as Stripe.Price);
+        const tier = getTierFromPrice(price);
         const trialEndsAt = subscription.trial_end ? new Date(subscription.trial_end * 1000) : null;
 
         const data = {
@@ -294,7 +294,7 @@ billing.post('/webhook', async (c) => {
 
       const customerId = subscription.customer as string;
       const price = subscription.items.data[0]?.price;
-      const tier: SubscriptionTier = shouldDowngrade(subscription.status) ? 'FREE' : getTierFromPrice(price as Stripe.Price);
+      const tier: SubscriptionTier = shouldDowngrade(subscription.status) ? 'FREE' : getTierFromPrice(price);
       const trialEndsAt = subscription.trial_end ? new Date(subscription.trial_end * 1000) : null;
 
       await updateByCustomer(customerId, {


### PR DESCRIPTION
## Problem
Users subscribing to TEAM plan (9/mo) were incorrectly resolved to FREE tier.

## Root Cause
The `subscription.created/updated/deleted` webhook handlers used the raw webhook event payload directly without expanding the price object from the Stripe API. This could result in incomplete price data, causing `getTierFromPrice` to fail matching and default to FREE.

## Fix
1. **Re-fetch subscription** in webhook handlers with `expand: ['items.data.price']` to guarantee full price data
2. **Upgraded `getTierFromPrice`** to accept full `Stripe.Price` object (was string ID only)
3. **Added `lookup_key` fallback** — checks `team_monthly`/`pro_monthly` keys if price ID comparison fails
4. **Added debug logging** for tier resolution to make future mismatches immediately visible in Railway logs

## Testing
- Verified `STRIPE_PRICE_TEAM=price_1SxME2KpOLoEYWXFufLIjtxG` matches Stripe dashboard
- Code review confirms primary ID check + lookup_key fallback covers all resolution paths
- Debug logging will confirm correct resolution on next webhook event

## Commits
- `04f01bd` chore: add detailed logging for Stripe price ID mismatch debugging
- `403b8b0` fix(billing): robust tier resolution with lookup_key fallback
- `aa246b0` fix(billing): expand subscription price in webhooks to ensure lookup_key availability